### PR TITLE
Fix header comp height on search toggle

### DIFF
--- a/packages/header/src/scss/_component.scss
+++ b/packages/header/src/scss/_component.scss
@@ -110,10 +110,10 @@
         .nav-search {
             height: 0;
             overflow: hidden;
-            transition: max-height .25s, padding-top .25s, padding-bottom .25s;
+            transition: height .25s, padding-top .25s, padding-bottom .25s;
 
             &--open {
-                height: max-content;
+                height: auto;
                 padding-top: core.$space-sm;
                 padding-bottom: core.$space-sm;
             }


### PR DESCRIPTION
I have fixed the height issue on header component when you search toggle. However the fix doesn't work on IE < 11. It works on Edge though.