### PR TITLE
Header, Main Nav accessibility updates

### DIFF
--- a/packages/header/src/scss/_component.scss
+++ b/packages/header/src/scss/_component.scss
@@ -91,10 +91,6 @@
                                 background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath d='M1.715 14.285l12.57-12.57m0 12.57L1.715 1.715' stroke='%23000' stroke-width='.75' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
                             }
                         }
-
-                        /*&:focus {
-                            outline: none;
-                        }*/
                     }
                 }
 

--- a/packages/header/src/scss/_component.scss
+++ b/packages/header/src/scss/_component.scss
@@ -92,9 +92,9 @@
                             }
                         }
 
-                        &:focus {
+                        /*&:focus {
                             outline: none;
-                        }
+                        }*/
                     }
                 }
 
@@ -114,10 +114,12 @@
         .nav-search {
             height: 0;
             overflow: hidden;
+            visibility: hidden;
             transition: height .25s, padding-top .25s, padding-bottom .25s;
 
             &--open {
                 height: auto;
+                visibility: visible;
                 padding-top: core.$space-sm;
                 padding-bottom: core.$space-sm;
             }

--- a/packages/site-header/src/js/site-header-navigation.es6.js
+++ b/packages/site-header/src/js/site-header-navigation.es6.js
@@ -155,7 +155,7 @@ class MainNavigation {
     } else if (parent === nav.lastElementChild) {
       // If we tab past the last child, toggle this level.
       if (event.key === 'Tab' && event.shiftKey === false) {
-        //this.closeLevel(nav, nav.parentNode);
+        this.closeLevel(nav, nav.parentNode);
       }
     }
 

--- a/packages/storybook-html/src/components/header/header.html
+++ b/packages/storybook-html/src/components/header/header.html
@@ -17,7 +17,7 @@
                     <li><a href="https://giving.uq.edu.au/">Give now</a></li>
                     <li><a href="https://my.uq.edu.au/">my.UQ</a></li>
                     <li class="menu-global__search-toggle">
-                        <button class="search-toggle__button">Search</button>
+                        <button class="search-toggle__button">Toggle Search</button>
                     </li>
                 </ul>
             </nav>

--- a/packages/storybook-html/src/components/header/header.html
+++ b/packages/storybook-html/src/components/header/header.html
@@ -28,7 +28,7 @@
                     <legend class="hidden">
                         <span class="nav-search__title">What are you looking for?</span>
                     </legend>
-                    <span class="nav-search__title">What are you looking for?</span>
+                    <span class="nav-search__title" tabindex="0">What are you looking for?</span>
                     <div class="nav-search__scope">
                         <div class="nav-search__scope__radio-wrapper">
                             <div class="form-item">

--- a/packages/storybook-html/src/components/header/header.html
+++ b/packages/storybook-html/src/components/header/header.html
@@ -5,7 +5,7 @@
                 <a class="logo--large" href="https://www.uq.edu.au/"><img alt="The University of Queensland" src="https://static.uq.net.au/v11/logos/corporate/uq-lockup-landscape--reversed.svg"></a>
                 <a class="logo--small" href="https://www.uq.edu.au/"><img alt="The University of Queensland" src="https://static.uq.net.au/v11/logos/corporate/uq-logo--reversed.svg"></a>
             </div>
-            <nav class="menu-global">
+            <nav class="menu-global" aria-label="Global navigation">
                 <ul>
                     <li><a href="https://www.uq.edu.au/contacts/">Contacts</a></li>
                     <li><a href="https://future-students.uq.edu.au/">Study</a></li>
@@ -53,7 +53,7 @@
                 </div>
             </form>
 
-            <nav class="menu-global">
+            <nav class="menu-global" aria-label="Global navigation">
                 <ul>
                     <li><a href="https://www.uq.edu.au/contacts/">Contacts</a></li>
                     <li><a href="https://www.uq.edu.au/news/">News</a></li>

--- a/packages/storybook-html/src/components/header/header_no-local-search.html
+++ b/packages/storybook-html/src/components/header/header_no-local-search.html
@@ -17,7 +17,7 @@
                     <li><a href="https://giving.uq.edu.au/">Give now</a></li>
                     <li><a href="https://my.uq.edu.au/">my.UQ</a></li>
                     <li class="menu-global__search-toggle">
-                        <button class="search-toggle__button">Search</button>
+                        <button class="search-toggle__button">Toggle Search</button>
                     </li>
                 </ul>
             </nav>
@@ -28,8 +28,8 @@
                     <legend class="hidden">
                         <span class="nav-search__title">What are you looking for?</span>
                     </legend>
-                    <span class="nav-search__title">What are you looking for?</span>
-                    <div class="nav-search__scope">Search all UQ websites</div>
+                    <span class="nav-search__title" tabindex="0">What are you looking for?</span>
+                    <div class="nav-search__scope" tabindex="0">Search all UQ websites</div>
                 </fieldset>
                 <div class="nav-search__query">
                     <span class="search-query__wrapper">

--- a/packages/storybook-html/src/components/intro/kitchen-sink.html
+++ b/packages/storybook-html/src/components/intro/kitchen-sink.html
@@ -127,8 +127,7 @@
               <a href="/study/medicine">Medicine</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/science-mathematics"
-                >Science and Mathematics</a>
+              <a href="/study/science-mathematics">Science and Mathematics</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
               <a href="/study/micromasters-uqx">MicroMasters and UQx</a>
@@ -188,13 +187,13 @@
           </ul>
         </li>
         <li class="uq-site-header__navigation__list-item">
-          <a href="/events" aria-expanded="false">Events</a>
+          <a href="/events">Events</a>
         </li>
         <li class="uq-site-header__navigation__list-item">
-          <a href="/stories" aria-expanded="false">Stories</a>
+          <a href="/stories">Stories</a>
         </li>
         <li class="uq-site-header__navigation__list-item">
-          <a href="/contact-us" aria-expanded="false">Contact</a>
+          <a href="/contact-us">Contact</a>
         </li>
       </ul>
     </nav>

--- a/packages/storybook-html/src/components/intro/kitchen-sink.html
+++ b/packages/storybook-html/src/components/intro/kitchen-sink.html
@@ -6,7 +6,7 @@
               <a class="logo--large" href="https://www.uq.edu.au/"><img alt="The University of Queensland" src="https://static.uq.net.au/v11/logos/corporate/uq-lockup-landscape--reversed.svg"></a>
               <a class="logo--small" href="https://www.uq.edu.au/"><img alt="The University of Queensland" src="https://static.uq.net.au/v11/logos/corporate/uq-logo--reversed.svg"></a>
           </div>
-          <nav class="menu-global">
+          <nav class="menu-global" aria-label="Global navigation">
               <ul>
                   <li><a href="https://www.uq.edu.au/contacts/">Contacts</a></li>
                   <li><a href="https://future-students.uq.edu.au/">Study</a></li>
@@ -18,7 +18,7 @@
                   <li><a href="https://giving.uq.edu.au/">Give now</a></li>
                   <li><a href="https://my.uq.edu.au/">my.UQ</a></li>
                   <li class="menu-global__search-toggle">
-                      <button class="search-toggle__button">Search</button>
+                      <button class="search-toggle__button">Toggle Search</button>
                   </li>
               </ul>
           </nav>
@@ -29,7 +29,7 @@
                   <legend class="hidden">
                       <span class="nav-search__title">What are you looking for?</span>
                   </legend>
-                  <span class="nav-search__title">What are you looking for?</span>
+                  <span class="nav-search__title" tabindex="0">What are you looking for?</span>
                   <div class="nav-search__scope">
                       <div class="nav-search__scope__radio-wrapper">
                           <div class="form-item">
@@ -54,7 +54,7 @@
               </div>
           </form>
 
-          <nav class="menu-global">
+          <nav class="menu-global" aria-label="Global navigation">
               <ul>
                   <li><a href="https://www.uq.edu.au/contacts/">Contacts</a></li>
                   <li><a href="https://www.uq.edu.au/news/">News</a></li>
@@ -86,104 +86,104 @@
 
   <!-- Navigation Menu  -->
   <div class="uq-site-header__navigation-container">
-    <nav class="uq-site-header__navigation" id="jsNav">
+    <nav class="uq-site-header__navigation" aria-label="Site navigation" id="jsNav">
       <ul class="uq-site-header__navigation__list
                  uq-site-header__navigation__list--level-1">
         <li class="uq-site-header__navigation__list-item
                    uq-site-header__navigation__list-item--has-subnav
                    uq-site-header__navigation__list-item--active">
-          <a href="/study" aria-expanded="false">Study</a>
+          <a href="/study" aria-haspopup="true" aria-expanded="false">Study</a>
           <span class="uq-site-header__navigation__sub-toggle">Open</span>
           <ul class="uq-site-header__navigation__list
-                     uq-site-header__navigation__list--level-2">
+                     uq-site-header__navigation__list--level-2" aria-label="Study submenu">
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/programs" aria-expanded="false">Find a program</a>
+              <a href="/study/programs">Find a program</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/agriculture-environment" aria-expanded="false">Agriculture and Environment</a>
+              <a href="/study/agriculture-environment">Agriculture and Environment</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/architecture-planning" aria-expanded="false">Architecture and Planning</a>
+              <a href="/study/architecture-planning">Architecture and Planning</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/arts-humanities-social-sciences" aria-expanded="false">Arts, Humanities and Social Sciences</a>
+              <a href="/study/arts-humanities-social-sciences">Arts, Humanities and Social Sciences</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/business-economics" aria-expanded="false">Business and Economics</a>
+              <a href="/study/business-economics">Business and Economics</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/education" aria-expanded="false">Education</a>
+              <a href="/study/education">Education</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/engineering-computing" aria-expanded="false">Engineering and Computing</a>
+              <a href="/study/engineering-computing">Engineering and Computing</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/health-behavioural-sciences" aria-expanded="false">Health and Behavioural Sciences</a>
+              <a href="/study/health-behavioural-sciences">Health and Behavioural Sciences</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/law" aria-expanded="false">Law</a>
+              <a href="/study/law">Law</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/medicine" aria-expanded="false">Medicine</a>
+              <a href="/study/medicine">Medicine</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/science-mathematics" aria-expanded="false"
+              <a href="/study/science-mathematics"
                 >Science and Mathematics</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/micromasters-uqx" aria-expanded="false">MicroMasters and UQx</a>
+              <a href="/study/micromasters-uqx">MicroMasters and UQx</a>
             </li>
           </ul>
         </li>
         <li class="uq-site-header__navigation__list-item
                    uq-site-header__navigation__list-item--has-subnav">
-          <a href="/admissions" aria-expanded="false">Admissions</a>
+          <a href="/admissions" aria-haspopup="true" aria-expanded="false">Admissions</a>
           <span class="uq-site-header__navigation__sub-toggle">Open</span>
           <ul class="uq-site-header__navigation__list 
-                     uq-site-header__navigation__list--level-2">
+                     uq-site-header__navigation__list--level-2" aria-label="Admissions submenu">
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/undergraduate" aria-expanded="false">Undergraduate</a>
+              <a href="/admissions/undergraduate">Undergraduate</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/honours" aria-expanded="false">Honours</a>
+              <a href="/admissions/honours">Honours</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/postgraduate-coursework" aria-expanded="false">Postgraduate coursework</a>
+              <a href="/admissions/postgraduate-coursework">Postgraduate coursework</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/higher-degree-research" aria-expanded="false">Higher degree by research</a>
+              <a href="/admissions/higher-degree-research">Higher degree by research</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/cross-institutional-study" aria-expanded="false">Cross-institutional study</a>
+              <a href="/admissions/cross-institutional-study">Cross-institutional study</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/non-award-study" aria-expanded="false">Non-award study</a>
+              <a href="/admissions/non-award-study">Non-award study</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/doctor-medicine" aria-expanded="false">Doctor of Medicine</a>
+              <a href="/admissions/doctor-medicine">Doctor of Medicine</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="https://www.uq.edu.au/studyabroad/how-to-apply" aria-expanded="false">Study abroad and incoming exchange</a>
+              <a href="https://www.uq.edu.au/studyabroad/how-to-apply">Study abroad and incoming exchange</a>
             </li>
           </ul>
         </li>
         <li class="uq-site-header__navigation__list-item
                    uq-site-header__navigation__list-item--has-subnav">
-          <a href="/university-life" aria-expanded="false">University life</a>
+          <a href="/university-life" aria-haspopup="true" aria-expanded="false">University life</a>
           <span class="uq-site-header__navigation__sub-toggle">Open</span>
           <ul class="uq-site-header__navigation__list 
-                     uq-site-header__navigation__list--level-2">
+                     uq-site-header__navigation__list--level-2" aria-label="University life submenu">
             <li class="uq-site-header__navigation__list-item">
-              <a href="/university-life/living-in-brisbane" aria-expanded="false">Living in Brisbane</a>
+              <a href="/university-life/living-in-brisbane">Living in Brisbane</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/university-life/getting-prepared-to-come-to-australia" aria-expanded="false">Getting prepared to come to Australia</a>
+              <a href="/university-life/getting-prepared-to-come-to-australia">Getting prepared to come to Australia</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/university-life/campuses-research-sites" aria-expanded="false">Campuses and research sites</a>
+              <a href="/university-life/campuses-research-sites">Campuses and research sites</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/university-life/campus-tours" aria-expanded="false">Campus tours</a>
+              <a href="/university-life/campus-tours">Campus tours</a>
             </li>
           </ul>
         </li>

--- a/packages/storybook-html/src/components/site-header/site-header.html
+++ b/packages/storybook-html/src/components/site-header/site-header.html
@@ -19,111 +19,112 @@
         <li class="uq-site-header__navigation__list-item
                    uq-site-header__navigation__list-item--has-subnav
                    uq-site-header__navigation__list-item--active">
-          <a href="/study" aria-expanded="false">Study</a>
+          <a href="/study" aria-haspopup="true" aria-expanded="false">Study</a>
           <span class="uq-site-header__navigation__sub-toggle">Open</span>
           <ul class="uq-site-header__navigation__list
-                     uq-site-header__navigation__list--level-2">
+                     uq-site-header__navigation__list--level-2" aria-label="Study">
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/programs" aria-expanded="false">Find a program</a>
+              <a href="/study/programs">Find a program</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/agriculture-environment" aria-expanded="false">Agriculture and Environment</a>
+              <a href="/study/agriculture-environment">Agriculture and Environment</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/architecture-planning" aria-expanded="false">Architecture and Planning</a>
+              <a href="/study/architecture-planning">Architecture and Planning</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/arts-humanities-social-sciences" aria-expanded="false">Arts, Humanities and Social Sciences</a>
+              <a href="/study/arts-humanities-social-sciences">Arts, Humanities and Social Sciences</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/business-economics" aria-expanded="false">Business and Economics</a>
+              <a href="/study/business-economics">Business and Economics</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/education" aria-expanded="false">Education</a>
+              <a href="/study/education">Education</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/engineering-computing" aria-expanded="false">Engineering and Computing</a>
+              <a href="/study/engineering-computing">Engineering and Computing</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/health-behavioural-sciences" aria-expanded="false">Health and Behavioural Sciences</a>
+              <a href="/study/health-behavioural-sciences">Health and Behavioural Sciences</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/law" aria-expanded="false">Law</a>
+              <a href="/study/law">Law</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/medicine" aria-expanded="false">Medicine</a>
+              <a href="/study/medicine">Medicine</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/science-mathematics" aria-expanded="false"
+              <a href="/study/science-mathematics"
                 >Science and Mathematics</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/study/micromasters-uqx" aria-expanded="false">MicroMasters and UQx</a>
+              <a href="/study/micromasters-uqx">MicroMasters and UQx</a>
             </li>
           </ul>
         </li>
         <li class="uq-site-header__navigation__list-item
                    uq-site-header__navigation__list-item--has-subnav">
-          <a href="/admissions" aria-expanded="false">Admissions</a>
+          <a href="/admissions" aria-haspopup="true" aria-expanded="false">Admissions</a>
           <span class="uq-site-header__navigation__sub-toggle">Open</span>
           <ul class="uq-site-header__navigation__list 
-                     uq-site-header__navigation__list--level-2">
+                     uq-site-header__navigation__list--level-2" aria-label="Admissions">
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/undergraduate" aria-expanded="false">Undergraduate</a>
+              <a href="/admissions/undergraduate">Undergraduate</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/honours" aria-expanded="false">Honours</a>
+              <a href="/admissions/honours">Honours</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/postgraduate-coursework" aria-expanded="false">Postgraduate coursework</a>
+              <a href="/admissions/postgraduate-coursework">Postgraduate coursework</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/higher-degree-research" aria-expanded="false">Higher degree by research</a>
+              <a href="/admissions/higher-degree-research">Higher degree by research</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/cross-institutional-study" aria-expanded="false">Cross-institutional study</a>
+              <a href="/admissions/cross-institutional-study">Cross-institutional study</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/non-award-study" aria-expanded="false">Non-award study</a>
+              <a href="/admissions/non-award-study">Non-award study</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/admissions/doctor-medicine" aria-expanded="false">Doctor of Medicine</a>
+              <a href="/admissions/doctor-medicine">Doctor of Medicine</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="https://www.uq.edu.au/studyabroad/how-to-apply" aria-expanded="false">Study abroad and incoming exchange</a>
+              <a href="https://www.uq.edu.au/studyabroad/how-to-apply">Study abroad and incoming exchange</a>
             </li>
           </ul>
         </li>
         <li class="uq-site-header__navigation__list-item
                    uq-site-header__navigation__list-item--has-subnav">
-          <a href="/university-life" aria-expanded="false">University life</a>
+          <a href="/university-life" aria-haspopup="true" aria-expanded="false">University life</a>
           <span class="uq-site-header__navigation__sub-toggle">Open</span>
           <ul class="uq-site-header__navigation__list 
-                     uq-site-header__navigation__list--level-2">
+                     uq-site-header__navigation__list--level-2" aria-label="University life">
             <li class="uq-site-header__navigation__list-item">
-              <a href="/university-life/living-in-brisbane" aria-expanded="false">Living in Brisbane</a>
+              <a href="/university-life/living-in-brisbane">Living in Brisbane</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/university-life/getting-prepared-to-come-to-australia" aria-expanded="false">Getting prepared to come to Australia</a>
+              <a href="/university-life/getting-prepared-to-come-to-australia">Getting prepared to come to Australia</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/university-life/campuses-research-sites" aria-expanded="false">Campuses and research sites</a>
+              <a href="/university-life/campuses-research-sites">Campuses and research sites</a>
             </li>
             <li class="uq-site-header__navigation__list-item">
-              <a href="/university-life/campus-tours" aria-expanded="false">Campus tours</a>
+              <a href="/university-life/campus-tours">Campus tours</a>
             </li>
           </ul>
         </li>
         <li class="uq-site-header__navigation__list-item">
-          <a href="/events" aria-expanded="false">Events</a>
+          <a href="/events" aria-haspopup="false" aria-expanded="false">Events</a>
         </li>
         <li class="uq-site-header__navigation__list-item">
-          <a href="/stories" aria-expanded="false">Stories</a>
+          <a href="/stories" aria-haspopup="false" aria-expanded="false">Stories</a>
         </li>
         <li class="uq-site-header__navigation__list-item">
-          <a href="/contact-us" aria-expanded="false">Contact</a>
+          <a href="/contact-us" aria-haspopup="false" aria-expanded="false">Contact</a>
         </li>
       </ul>
     </nav>
   </div>
 </div>
+

--- a/packages/storybook-html/src/components/site-header/site-header.html
+++ b/packages/storybook-html/src/components/site-header/site-header.html
@@ -13,7 +13,7 @@
 
   <!-- Navigation Menu  -->
   <div class="uq-site-header__navigation-container">
-    <nav class="uq-site-header__navigation" aria-label="Main navigation" id="jsNav">
+    <nav class="uq-site-header__navigation" aria-label="Site navigation" id="jsNav">
       <ul class="uq-site-header__navigation__list
                  uq-site-header__navigation__list--level-1">
         <li class="uq-site-header__navigation__list-item
@@ -22,7 +22,7 @@
           <a href="/study" aria-haspopup="true" aria-expanded="false">Study</a>
           <span class="uq-site-header__navigation__sub-toggle">Open</span>
           <ul class="uq-site-header__navigation__list
-                     uq-site-header__navigation__list--level-2" aria-label="Study">
+                     uq-site-header__navigation__list--level-2" aria-label="Study submenu">
             <li class="uq-site-header__navigation__list-item">
               <a href="/study/programs">Find a program</a>
             </li>
@@ -67,7 +67,7 @@
           <a href="/admissions" aria-haspopup="true" aria-expanded="false">Admissions</a>
           <span class="uq-site-header__navigation__sub-toggle">Open</span>
           <ul class="uq-site-header__navigation__list 
-                     uq-site-header__navigation__list--level-2" aria-label="Admissions">
+                     uq-site-header__navigation__list--level-2" aria-label="Admissions submenu">
             <li class="uq-site-header__navigation__list-item">
               <a href="/admissions/undergraduate">Undergraduate</a>
             </li>
@@ -99,7 +99,7 @@
           <a href="/university-life" aria-haspopup="true" aria-expanded="false">University life</a>
           <span class="uq-site-header__navigation__sub-toggle">Open</span>
           <ul class="uq-site-header__navigation__list 
-                     uq-site-header__navigation__list--level-2" aria-label="University life">
+                     uq-site-header__navigation__list--level-2" aria-label="University life submenu">
             <li class="uq-site-header__navigation__list-item">
               <a href="/university-life/living-in-brisbane">Living in Brisbane</a>
             </li>

--- a/packages/storybook-html/src/components/site-header/site-header.html
+++ b/packages/storybook-html/src/components/site-header/site-header.html
@@ -13,7 +13,7 @@
 
   <!-- Navigation Menu  -->
   <div class="uq-site-header__navigation-container">
-    <nav class="uq-site-header__navigation" id="jsNav">
+    <nav class="uq-site-header__navigation" aria-label="Main navigation" id="jsNav">
       <ul class="uq-site-header__navigation__list
                  uq-site-header__navigation__list--level-1">
         <li class="uq-site-header__navigation__list-item
@@ -115,13 +115,13 @@
           </ul>
         </li>
         <li class="uq-site-header__navigation__list-item">
-          <a href="/events" aria-haspopup="false" aria-expanded="false">Events</a>
+          <a href="/events" aria-expanded="false">Events</a>
         </li>
         <li class="uq-site-header__navigation__list-item">
-          <a href="/stories" aria-haspopup="false" aria-expanded="false">Stories</a>
+          <a href="/stories" aria-expanded="false">Stories</a>
         </li>
         <li class="uq-site-header__navigation__list-item">
-          <a href="/contact-us" aria-haspopup="false" aria-expanded="false">Contact</a>
+          <a href="/contact-us" aria-expanded="false">Contact</a>
         </li>
       </ul>
     </nav>

--- a/packages/storybook-html/src/components/site-header/site-header.html
+++ b/packages/storybook-html/src/components/site-header/site-header.html
@@ -115,13 +115,13 @@
           </ul>
         </li>
         <li class="uq-site-header__navigation__list-item">
-          <a href="/events" aria-expanded="false">Events</a>
+          <a href="/events">Events</a>
         </li>
         <li class="uq-site-header__navigation__list-item">
-          <a href="/stories" aria-expanded="false">Stories</a>
+          <a href="/stories">Stories</a>
         </li>
         <li class="uq-site-header__navigation__list-item">
-          <a href="/contact-us" aria-expanded="false">Contact</a>
+          <a href="/contact-us">Contact</a>
         </li>
       </ul>
     </nav>


### PR DESCRIPTION
- Outline to Search toggle button reinstated
- Tabbing through hidden elements of header sorted, tabs through only when visible
- Tabbing through hidden submenu of site header sorted, tabs through only when visible
- Added aria-haspopup="true" to site header menu Level 1 lists that have submenus
- Removed aria-expanded="false" on submenu list items as it isn't required
- Added "aria-label" to both Main & Global navigation <nav>