### PR TITLE
Fix typo in Typography Usage title in storybook

### DIFF
--- a/packages/storybook-html/src/components/core/typography-applying.story.mdx
+++ b/packages/storybook-html/src/components/core/typography-applying.story.mdx
@@ -124,7 +124,7 @@ Font size should be a minimum of 16px.</td>
 </table>
 `;
 
-<Story name="Typogrphy Usage">{TypographyUsage.bind({})}</Story>
+<Story name="Typography Usage">{TypographyUsage.bind({})}</Story>
 
 ## Example usage
 


### PR DESCRIPTION
Fix a small typo in story title 👋 

![image](https://user-images.githubusercontent.com/101371/107464267-a82c7e80-6bab-11eb-8284-fdd7127c7360.png)
