### PR TITLE
CXP-14694: Fix erroneous matches on child pages

### DIFF
--- a/packages/alert/src/__tests__/__snapshots__/alerts.test.js.snap
+++ b/packages/alert/src/__tests__/__snapshots__/alerts.test.js.snap
@@ -76,3 +76,24 @@ Document {
   },
 }
 `;
+
+exports[`Alert default behaviour Should not match on child pages 1`] = `
+Document {
+  "elementsFromPoint": [Function],
+  "location": Location {
+    "assign": [Function],
+    "hash": "",
+    "host": "localhost",
+    "hostname": "localhost",
+    "href": "http://localhost/",
+    "origin": "http://localhost",
+    "pathname": "/",
+    "port": "",
+    "protocol": "http:",
+    "reload": [Function],
+    "replace": [Function],
+    "search": "",
+    "toString": [Function],
+  },
+}
+`;

--- a/packages/alert/src/__tests__/alerts.test.js
+++ b/packages/alert/src/__tests__/alerts.test.js
@@ -89,4 +89,18 @@ describe('Alert default behaviour', () => {
     })
     expect(container).toMatchSnapshot();
   });
+  it('Should not match on child pages', async () => {
+    const container = renderFromString(headerMarkup);
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'https://www.uq.edu.au/stuff/i-wish-i-had-known'
+      }
+    });
+    new Alerts(container.querySelector('.uq-alerts-global-container'));
+    await waitFor(() => {
+      // Should filter out the negated version.
+      expect(screen.getAllByRole('alert')).toHaveLength(2);
+    })
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/packages/alert/src/__tests__/fixtures/alerts.json
+++ b/packages/alert/src/__tests__/fixtures/alerts.json
@@ -6,6 +6,7 @@
       "dismissalIgnoreBefore": 0,
       "styleClass": "alert-info",
       "showOnPages": [
+        "https:\/\/www.uq.edu.au",
         "https:\/\/study.uq.edu.au\/",
         "http:\/\/127.0.0.1:8080\/stuff\/*"
       ],
@@ -27,6 +28,7 @@
       "dismissalIgnoreBefore": 0,
       "styleClass": "alert-info",
       "showOnPages": [
+        "https:\/\/www.uq.edu.au",
         "https:\/\/study.uq.edu.au\/",
         "http:\/\/127.0.0.1:8080\/stuff\/*"
       ],

--- a/packages/alert/src/js/alerts.js
+++ b/packages/alert/src/js/alerts.js
@@ -46,20 +46,20 @@ class Alerts {
       if (!alert.showOnPages.length) {
         return true;
       }
+      const href = window.location.href.replace(/\/+$/, '');
+      const hrefMatches = (page) => {
+        const expression = `${page}`
+          .replace(/\/+$/, '')
+          .replace(new RegExp(`[.\\\\+?\\[^\\]$(){}=!<>|:\\-]`, 'g'), '\\$&')
+          .concat('$');
+        return href.match(new RegExp(expression.replaceAll('*', '.*')));
+      };
       if (!alert.negateShowOnPages) {
         // Any match will do here.
-        return alert.showOnPages.find(page => {
-          const quoted = `${page}`
-            .replace(new RegExp(`[.\\\\+?\\[^\\]$(){}=!<>|:\\-]`, 'g'), '\\$&');
-          return window.location.href.match(new RegExp(quoted.replaceAll('*', '.*')));
-        }) !== undefined;
+        return alert.showOnPages.find(hrefMatches) !== undefined;
       }
       // None should match here.
-      return alert.showOnPages.filter(page => {
-        const quoted = `${page}`
-          .replace(new RegExp(`[.\\\\+?\\[^\\]$(){}=!<>|:\\-]`, 'g'), '\\$&');
-        return window.location.href.match(new RegExp(quoted.replaceAll('*', '.*')));
-      }).length === 0;
+      return alert.showOnPages.filter(hrefMatches).length === 0;
     })
   }
 }


### PR DESCRIPTION
Currently if you specify `https://study.uq.edu.au` or `https://study.uq.edu.au/`as a pattern then `https://study.uq.edu.au/foo/bar` will also match. I _think_ this PR covers both cases as well as the inverse.