### PR TITLE
Updated Build references for storybook

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,7 @@
 
 # Build
 /packages/**/dist
-/packages/**/.out/
+/packages/**/storybook-static/
 
 # Linted separately
 /packages/icon/src/ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,4 +7,4 @@ package-lock.json
 
 # Build
 /packages/**/dist
-/packages/**/.out/
+/packages/**/storybook-static/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -5,4 +5,4 @@
 
 # Build
 /packages/**/dist
-/packages/**/.out/
+/packages/**/storybook-static/

--- a/packages/storybook-html/.gitignore
+++ b/packages/storybook-html/.gitignore
@@ -1,1 +1,1 @@
-.out/
+storybook-static/


### PR DESCRIPTION
Updates the references and ignore scripts for the storybook Build folder. 

Changed from .out to storybook-static