### PR TITLE
Make accordions re-entrant

### DIFF
--- a/packages/accordion/src/js/accordion.js
+++ b/packages/accordion/src/js/accordion.js
@@ -189,9 +189,10 @@ class accordion {
       }
     }
 
-    const accordions = document.querySelectorAll(`.${this.className}`);
+    const accordions = document.querySelectorAll(`.${this.className}:not([data-accordion-init]`);
 
     accordions.forEach((el) => {
+      el.dataset.accordionInit = '';
       const togglers = el.querySelectorAll(`.${this.className}__toggle`);
 
       togglers.forEach((el) => {
@@ -201,7 +202,7 @@ class accordion {
 
     // wrap contents of uq-accordion__content in a wrapper to apply padding and prevent animation jump
     const accordionContents = document.querySelectorAll(
-      `.${this.className}__content`
+      `.${this.className}:not([data-accordion-init] .${this.className}__content`
     );
     const accordionName = this.className;
 


### PR DESCRIPTION
Working in a setup where accordions can be added/removed from the page via ajax requests.
Need to be able to ensure the init code for an accordion only runs once per accordion.

This adds a `data-accordion-init` attribute to the accordion element when it has had the listeners run.

Subsequent calls to `new accordion()` won't re-run init code for an already setup item
