### PR TITLE
chore: Persist credentials

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
       - name: "⬇️ Checkout"
         uses: actions/checkout@v3
         with:
+          persist-credentials: false
           fetch-depth: 0
           token: ${{ secrets.UQDS_PERSONAL_ACCESS_TOKEN }}
 


### PR DESCRIPTION
Fix for regression tests not being created on Publish. 

`persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.`

https://github.com/orgs/community/discussions/25702
 
If an action pushes code using the repository’s GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.

The regression process is triggered on push. 