### PR TITLE
fix: don't show chevron for active nav links

### DIFF
--- a/packages/navigation/src/scss/_local-nav.scss
+++ b/packages/navigation/src/scss/_local-nav.scss
@@ -53,19 +53,6 @@
   padding: 0;
 }
 
-.uq-local-nav--has-children {
-  & > .uq-local-nav__link {
-    background-image: url(icon.get-icon(
-      "standard--chevron-down-sml",
-      core.$black
-    ));
-    background-repeat: no-repeat;
-    background-size: 24px;
-    background-position: right center;
-    padding-inline-end: core.$space-l;
-  }
-}
-
 .uq-local-nav__child,
 .uq-local-nav__grandchild {
   margin-bottom: 0;
@@ -90,4 +77,21 @@
 .uq-local-nav--active-link {
   background-color: core.$grey-50;
   font-weight: core.$font-weight-medium;
+}
+
+.uq-local-nav--has-children {
+  & .uq-local-nav__link {
+    background-image: url(icon.get-icon(
+      "standard--chevron-down-sml",
+      core.$black
+    ));
+    background-repeat: no-repeat;
+    background-size: 24px;
+    background-position: right center;
+    padding-inline-end: core.$space-l;
+  }
+
+  & .uq-local-nav--active-link {
+    background-image: none;
+  }
 }


### PR DESCRIPTION
Basic fix to hide the chevron for nav parents that are active.

![Screenshot 2024-02-19 at 2 21 23 pm](https://github.com/uq-its-ss/design-system/assets/89008/4d8cae94-37c5-4bbf-83ba-3d9dc3e6e3c2)
