### PR TITLE
fix: ITSADSSD-55778 Hero-basic, closing div for uq-contianer in wrong location

### DIFF
--- a/packages/storybook-html/stories/components/hero-basic/hero-basic.stories.js
+++ b/packages/storybook-html/stories/components/hero-basic/hero-basic.stories.js
@@ -94,10 +94,10 @@ export const HeroBasic = {
           </div>
         </div>
       </div>
-    </div>
-  </div>`
+    </div>`
         : ""
     }
+  </div>
 </div>`,
 };
 


### PR DESCRIPTION
Closing div for uq-container was incorrectly wrapped in the tabs function. Which resulted in the non tab version of HERO-BASIC rendering without a closing DIV for uq-container class

![Screenshot 2024-04-16 at 11 13 10 AM](https://github.com/uq-its-ss/design-system/assets/8379323/43a90408-d899-40e3-a480-b63db0d3fe3c)
