### PR TITLE
ITSADSSD-59448 update prerelease workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -74,4 +74,4 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor}}@users.noreply.github.com"
-          npx lerna publish --conventional-commits --conventional-prerelease --yes
+          npx lerna publish --conventional-commits --conventional-prerelease --dist-tag alpha --yes


### PR DESCRIPTION
Current Prerelease workflow is publish packages with the default distribution tag, this update should now publish Prereleases with the tag alpha

Lerna --dist-tag alpha