### PR TITLE
chore: Fix the workspaces reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "workspaces": [
-        "./packages/*"
+        "packages/*"
       ],
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -13613,9 +13613,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.68",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.68.tgz",
-      "integrity": "sha512-FgMdJlma0OzUYlbrtZ4AeXjKxKPk6KT8WOP8BjcqxWtlg8qyJQjRzPJzUtUn5GBg1oQ26hFs7HOOHJMYiJRnvQ==",
+      "version": "1.5.69",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.69.tgz",
+      "integrity": "sha512-zz4e7EbJqqtdQtwt61ZYKrfEYlV0HpGbIGRVFGOO9YBZIhg0BDXtBcWxpqyAm6oyPl2Zp8tc5FrPpCZQH/Yazg==",
       "dev": true
     },
     "node_modules/emittery": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "ISC",
   "workspaces": [
-    "./packages/*"
+    "packages/*"
   ],
   "devDependencies": {
     "@babel/core": "^7.26.0",


### PR DESCRIPTION
After updating lerna was failing to identify monorepo packages. 

Testing indicates this was related to package.json workspaces setting. 

I have modified to remove unneeded `./`

