### PR TITLE
ITSADSSD-59373: News home layout mobile stacking order

### DIFF
--- a/packages/layout/src/scss/_sidebar-right-layout.scss
+++ b/packages/layout/src/scss/_sidebar-right-layout.scss
@@ -3,11 +3,10 @@
 .uq-sidebar-right-layout {
   display: flex;
   flex-direction: column;
-  gap: 32px;
 
   @media #{core.$screen-lg-up} {
     display: grid;
-    gap: 32px;
+    gap: 0 32px;
     grid-template-columns:
       1fr
       296px;
@@ -20,10 +19,33 @@
   }
 }
 
-.uq-sidebar-right-layout__sidebar {
-  grid-column: 2 / span 1;
-}
-
 .uq-sidebar-right-layout__main {
   grid-column: 1 / span 1;
+
+  &.uq-sidebar-right-layout__first {
+    grid-row: 1 / span 2;
+  }
+
+  &.uq-sidebar-right-layout__second {
+    grid-row: 3 / span 1;
+  }
+}
+
+.uq-sidebar-right-layout__sidebar {
+  grid-column: 2 / span 1;
+
+  &.uq-sidebar-right-layout__first {
+    grid-row: 1 / span 1;
+  }
+
+  &.uq-sidebar-right-layout__second {
+    grid-row: 2 / span 2;
+  }
+}
+
+/* Allow source based ordering of blocks for news homepage layout. */
+.uq-sidebar-right-layout:has(.uq-sidebar-right-layout__first) {
+  @media #{core.$screen-lg-up} {
+    grid-template-rows: min-content min-content 1fr;
+  }
 }

--- a/packages/storybook-html/stories/layout/page-layouts/sidebar-right/sidebar-right.mdx
+++ b/packages/storybook-html/stories/layout/page-layouts/sidebar-right/sidebar-right.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas } from "@storybook/blocks";
+import { Meta, Canvas, Source } from "@storybook/blocks";
 import StatusBadge from "../../../../.storybook/custom/components/StatusBadge";
 import * as SidebarRightStories from "./sidebar-right.stories";
 
@@ -23,25 +23,17 @@ Then implement the component as per the HTML example below.
 `.uq-section` elements are then used within `.uq-sidebar-right-layout__main` and `.uq-sidebar-right-layout__sidebar` to
 provide correct **section spacing**.
 
-<Canvas of={SidebarRightStories.SidebarRight} />
+<Canvas of={SidebarRightStories.SidebarRight} sourceState="none" />
 
-```html
-<div class="uq-container">
-  <div class="uq-sidebar-right-layout">
-    <div class="uq-sidebar-right-layout__main">
-      <div class="uq-section"></div>
-    </div>
-    <div class="uq-sidebar-right-layout__sidebar">
-      <div class="uq-section"></div>
-    </div>
-  </div>
-</div>
-```
+<Source of={SidebarRightStories.SidebarRight} />
 
 ### Examples
 
 #### Sidebar right layout with News cards.
 
 This example uses the `.uq-reduced-spacing` class for smaller gaps between sections and cards.
+
+Multiple main and sidebar elements can be used combined with the `.uq-sidebar-right-layout__first` and `.uq-sidebar-right-layout__second` to achieve
+complex mobile stack ordering whilst maintaining the desktop grid layout.
 
 <Canvas of={SidebarRightStories.NewsExample} />

--- a/packages/storybook-html/stories/layout/page-layouts/sidebar-right/sidebar-right.stories.js
+++ b/packages/storybook-html/stories/layout/page-layouts/sidebar-right/sidebar-right.stories.js
@@ -35,7 +35,7 @@ export const NewsExample = {
   render: () => `
 <div class="uq-container">
   <div class="uq-sidebar-right-layout uq-reduced-spacing">
-    <div class="uq-sidebar-right-layout__main">
+    <div class="uq-sidebar-right-layout__main uq-sidebar-right-layout__first">
       <div class="uq-section">
         <div class="uq-card-grid">
           ${FeatureCard({ title: "How to host a climate positive Olympic Games", description: "Online gaming could be the answer to engaging young Queenslanders to help create a legacy for the city from the Brisbane 2032 Olympic and Paralympic Games.", image: "images/news/feature.jpg", topLabel: null })}
@@ -47,6 +47,21 @@ export const NewsExample = {
           </div>
         </div>
       </div>
+    </div>
+    <div class="uq-sidebar-right-layout__sidebar uq-sidebar-right-layout__first">
+      <div class="uq-section">
+        <div class="uq-section__header">
+          <h2 class="uq-section__title">Editors' pick</h2>
+        </div>
+        <div class="uq-card-grid">
+            ${LandscapeCard({ title: "Moving policy forward nanotechnology", image: "images/news/image-2.jpg", topLabel: null })}
+            ${LandscapeCard({ title: "From 'face of UQ' to champion of diversity", image: "images/news/image-1.jpg", topLabel: null })}
+            ${LandscapeCard({ title: "Gene editing for fun and profit: it’s a knockout!", image: "images/news/image-3.jpg", topLabel: null })}
+            ${LandscapeCard({ title: "Broome diaries: in search of bushfoods in the Kimberly region", image: "images/news/image-4.jpg", topLabel: null })}
+        </div>    
+      </div>
+    </div>
+    <div class="uq-sidebar-right-layout__main uq-sidebar-right-layout__second">
       <div class="uq-section">
         <div class="uq-section__header">
           <h2 class="uq-section__title">Science and technology news</h2>
@@ -69,18 +84,7 @@ export const NewsExample = {
         </div> 
       </div>
     </div>
-    <div class="uq-sidebar-right-layout__sidebar">
-      <div class="uq-section">
-        <div class="uq-section__header">
-          <h2 class="uq-section__title">Editors' pick</h2>
-        </div>
-        <div class="uq-card-grid">
-            ${LandscapeCard({ title: "Moving policy forward nanotechnology", image: "images/news/image-2.jpg", topLabel: null })}
-            ${LandscapeCard({ title: "From 'face of UQ' to champion of diversity", image: "images/news/image-1.jpg", topLabel: null })}
-            ${LandscapeCard({ title: "Gene editing for fun and profit: it’s a knockout!", image: "images/news/image-3.jpg", topLabel: null })}
-            ${LandscapeCard({ title: "Broome diaries: in search of bushfoods in the Kimberly region", image: "images/news/image-4.jpg", topLabel: null })}
-        </div>    
-      </div>
+    <div class="uq-sidebar-right-layout__sidebar uq-sidebar-right-layout__second">
       <div class="uq-section">
         <div class="uq-card-grid">
           ${Card({ title: "Subscribe to UQ News", description: "Get the latest from our newsroom." })}

--- a/packages/storybook-html/stories/templates/News/news-home.stories.js
+++ b/packages/storybook-html/stories/templates/News/news-home.stories.js
@@ -43,7 +43,9 @@ ${Level2Hero({ title: "News", description: "Get the latest from UQ News.", image
 ${NewsExample()}
 <div class="uq-section">
   <div class="uq-container">
-    <h2>Looking for specific news?</h2>
+    <div class="uq-section__header">
+      <h2 class="uq-section__title">Looking for specific news?</h2>
+    </div>
     <h3>Search by keyword</h3>
     ${SearchInput()}
     <h3>Browse by topic</h3>


### PR DESCRIPTION
I was able to achieve the mobile stacking order via a combination of source ordering and Grids.

By adding additional main/sidebar divs we can arrange the stack order on mobile and then place each div in the correct column/position using grid for tablet/desktop.

The only caveat being the main/first div must be taller than the sidebar/first div from a content perspective.

![Screenshot 2025-01-09 at 2 21 48 pm](https://github.com/user-attachments/assets/908d526c-5659-44c0-8033-28bbe9027bbd)
![Screenshot 2025-01-09 at 2 22 04 pm](https://github.com/user-attachments/assets/d37b6217-4482-4cbe-b2c7-89dfecf3860c)
