### PR TITLE
ITSADSSD-59702: Fix for alert package.json exports

### DIFF
--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -29,13 +29,24 @@
     "src/*",
     "dist/*"
   ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/uq-its-ss/design-system.git"
+  "main": "dist/js/uqds.js",
+  "module": "dist/mjs/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/mjs/index.js",
+      "require": "./dist/js/uqds.js"
+    },
+    "./src/js/*": "./src/js/*.js",
+    "./src/scss/*": "./src/scss/*"
   },
+  "style": "dist/css/main.css",
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",
     "prepare": "gulp -f ../../gulpfile.js --cwd=. prepare"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/uq-its-ss/design-system.git"
   },
   "bugs": {
     "url": "https://github.com/uq-its-ss/design-system/issues"


### PR DESCRIPTION
The alert package didn't have style/main/exports for easy imports in sass/postcss/js. Adding these in as per other packages.