### PR TITLE
ITSADSSD-59374: Fix image css build

### DIFF
--- a/packages/image/src/scss/_image-carousel.scss
+++ b/packages/image/src/scss/_image-carousel.scss
@@ -1,6 +1,6 @@
 @use "@uqds/core/src/scss/global" as core;
 @use "@uqds/icon/src/scss/global" as icon;
-@use "../../../../node_modules/swiper/swiper.scss";
+@use "../../../../node_modules/swiper/swiper";
 
 .uq-image-carousel {
   container-type: inline-size;

--- a/packages/image/src/scss/_image-carousel.scss
+++ b/packages/image/src/scss/_image-carousel.scss
@@ -1,6 +1,6 @@
 @use "@uqds/core/src/scss/global" as core;
 @use "@uqds/icon/src/scss/global" as icon;
-@import "~swiper/css";
+@use "../../../../node_modules/swiper/swiper.scss";
 
 .uq-image-carousel {
   container-type: inline-size;


### PR DESCRIPTION
I was using a path reference that worked in storybook but not in gulp. 

Uses the relative path back to node_modules which works for both.