### PR TITLE
[ITSADSSD-60914]: Story cards in 1x card grids should display as full cards

### DIFF
--- a/packages/card/src/scss/_story-card.scss
+++ b/packages/card/src/scss/_story-card.scss
@@ -43,44 +43,46 @@ $story-card-small-container: 600px;
  * Mobile landscape/listing display.
  */
 
-.uq-story-card:not(.uq-story-card--feature) {
-  @media #{core.$screen-md-down} {
-    border-radius: 0;
-    border-inline-width: 0;
-    border-top-width: 0;
-    display: flex;
-    flex-direction: row-reverse;
-    align-items: start;
-    gap: core.$space-m;
-    padding-bottom: core.$space-m;
-    background-color: transparent;
-
-    &:has(a:hover) {
+.uq-card-grid:not(.uq-card-grid--target-1x) {
+  .uq-story-card:not(.uq-story-card--feature) {
+    @media #{core.$screen-md-down} {
+      border-radius: 0;
+      border-inline-width: 0;
+      border-top-width: 0;
+      display: flex;
+      flex-direction: row-reverse;
+      align-items: start;
+      gap: core.$space-m;
+      padding-bottom: core.$space-m;
       background-color: transparent;
-    }
 
-    & .uq-story-card__content {
-      padding: 0;
-    }
+      &:has(a:hover) {
+        background-color: transparent;
+      }
 
-    & .uq-story-card__image {
-      width: 120px;
-      height: 100px;
-      aspect-ratio: unset;
-      flex-shrink: 0;
-      margin-top: 6px;
-    }
+      & .uq-story-card__content {
+        padding: 0;
+      }
 
-    & .uq-story-card__description {
-      display: none;
-    }
+      & .uq-story-card__image {
+        width: 120px;
+        height: 100px;
+        aspect-ratio: unset;
+        flex-shrink: 0;
+        margin-top: 6px;
+      }
 
-    & .uq-story-card__top-label {
-      margin-bottom: 0;
-    }
+      & .uq-story-card__description {
+        display: none;
+      }
 
-    & .uq-story-card__bottom-label {
-      padding-top: core.$space-s;
+      & .uq-story-card__top-label {
+        margin-bottom: 0;
+      }
+
+      & .uq-story-card__bottom-label {
+        padding-top: core.$space-s;
+      }
     }
   }
 }


### PR DESCRIPTION
The story cards were being converted to landscape cards incorrectly when placed in 1x card grids.

![Screenshot 2025-01-23 at 10 15 57 am](https://github.com/user-attachments/assets/cbc05a5b-ca27-40ce-b6eb-5940220cf004)
