### PR TITLE
Itsadssd 62638 release updates

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 18
 
       - name: "📦️ Install dependencies"
-        run: npm install
+        run: npm ci
 
       - name: "🧹 Linting"
         run: npm run lint

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -62,6 +62,8 @@ jobs:
           GH_TOKEN: ${{ secrets.UQDS_PERSONAL_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          git reset --hard HEAD
+          git clean -fd
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor}}@users.noreply.github.com"
           npx lerna publish --conventional-commits --conventional-graduate --yes

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,13 +9,14 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # This condition prevents the workflow running FOR the Lerna publish commit itself
     if: ${{ ! startsWith(github.event.head_commit.message, 'chore(release):Publish') }}
     steps:
       - name: "⬇️ Checkout repo"
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          token: ${{ secrets.UQDS_PERSONAL_ACCESS_TOKEN }}
+          fetch-depth: 0 # Important to fetch all history and tags
+          token: ${{ secrets.UQDS_PERSONAL_ACCESS_TOKEN }} # Use PAT to allow pushing tags/commits later
 
       - name: "⎔ Setup node 18"
         uses: actions/setup-node@v3
@@ -23,7 +24,7 @@ jobs:
           node-version: 18
 
       - name: "📦️ Install dependencies"
-        run: npm install
+        run: npm ci
 
       - name: "🔐 Authenticate to NPM"
         run: |
@@ -32,6 +33,8 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # --- Steps for 'releases' branch ---
+      
       - name: "🧐 Version dry run"
         if: ${{ github.ref_name == 'releases' }}
         env:
@@ -39,7 +42,8 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor}}@users.noreply.github.com"          
+          git config user.email "${{ github.actor}}@users.noreply.github.com"
+          # Dry run for version bump ONLY, no tag/push yet       
           npx lerna version --conventional-commits --conventional-graduate --yes --no-git-tag-version --no-push || true
 
       - name: "⌛️ Wait for approval"
@@ -52,7 +56,8 @@ jobs:
           issue-title: 'Approve new release ✅'
           issue-body: >
             Please approve or deny the release of a new release.
-            [View the workflow output](https://github.com/uq-its-ss/design-system/actions/runs/${{ github.run_number }}) to confirm the version is as expected.
+            [View the workflow output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            to confirm the version is as expected.
 
           exclude-workflow-initiator-as-approver: false
 
@@ -62,12 +67,16 @@ jobs:
           GH_TOKEN: ${{ secrets.UQDS_PERSONAL_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          # Ensure clean state before publish, especially after dry run
           git reset --hard HEAD
           git clean -fd
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor}}@users.noreply.github.com"
+          # Publish: bumps version, creates tag vx.y.z, commits, pushes commit/tag, publishes to npm
           npx lerna publish --conventional-commits --conventional-graduate --yes
 
+      # --- Steps for 'master' branch ---
+      
       - name: "🐣 Publish alpha"
         if: ${{ github.ref_name == 'master' }}
         env:
@@ -76,4 +85,5 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor}}@users.noreply.github.com"
+          # Publish alpha: bumps version, creates tag vx.y.z-alpha.N, commits, pushes commit/tag, publishes to npm
           npx lerna publish --conventional-commits --conventional-prerelease --dist-tag alpha --yes

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
       - releases
+    paths-ignore:
+      - '**/package.json'
+      - '**/CHANGELOG.md'
 
 jobs:
   publish:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - master
       - releases
-    paths-ignore:
-      - '**/package.json'
-      - '**/CHANGELOG.md'
 
 jobs:
   publish:

--- a/.github/workflows/publish-sb.yml
+++ b/.github/workflows/publish-sb.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 18
 
       - name: "📦️ Install dependencies and build"
-        run: npm install
+        run: npm ci
 
       - name: "Build Storybook"
         run: |

--- a/.github/workflows/reg.yml
+++ b/.github/workflows/reg.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 18
 
       - name: "📦️ Install dependencies"
-        run: npm install
+        run: npm ci
 
       - name: "Build Storybook"
         run: |

--- a/lerna.json
+++ b/lerna.json
@@ -6,10 +6,12 @@
       "npmClientArgs": ["--no-package-lock"]
     },
     "publish": {
+      "ignoreChanges": ["**/*.md", "**/package.json", "**/package-lock.json"],
       "conventionalCommits": true,
       "allowBranch": ["master", "releases"]
     },
     "version": {
+      "ignoreChanges": ["**/*.md", "**/package.json", "**/package-lock.json"],
       "conventionalCommits": true,
       "allowBranch": ["master", "releases"],
       "message": "chore(release):Publish"


### PR DESCRIPTION
Workflow Changes to stop unnecessary version bumps:

Updated Workflows to use `npm ci` instead of `npm install`, for faster, more reliable, and strictly reproducible installs based exactly on the package-lock.json 

**publish-npm.yml updates**

Steps for 'releases' branch were doubling version bumps, added new publish steps to clear dry run changes in publish.

```
# Ensure clean state before publish, especially after dry run
git reset --hard HEAD
git clean -fd
``` 

Changes to `package.json` and `changelog.md` files were creating an endless update loop bumping versions for every package even if new changes did not exist. Updated `lerna.json` with `ignoreChanges` to avoid looped changes

```
"ignoreChanges": ["**/*.md", "**/package.json", "**/package-lock.json"],
```