### PR TITLE
ITSADSSD-60235: fix card hover icon bug

### DIFF
--- a/packages/card/src/scss/_card.scss
+++ b/packages/card/src/scss/_card.scss
@@ -67,6 +67,7 @@
       content: "";
       position: absolute;
       inset: 0;
+      z-index: 1;
     }
 
     &:focus {


### PR DESCRIPTION
[ITSADSSD-60235](https://jira.its.uq.edu.au/jira/browse/ITSADSSD-60235)
Fixes a bug where hovering the edge of the arrow icon on cards created a flicker. 

![image](https://github.com/user-attachments/assets/967de3aa-5288-4ab4-bcf5-d2aad2bfbad3)
