### PR TITLE
HOTFIX: Add main/styles export for pagination package.

### DIFF
--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -30,6 +30,7 @@
     "src/*",
     "dist/*"
   ],
+  "style": "dist/css/main.css",
   "scripts": {
     "prepare": "gulp -f ../../gulpfile.js --cwd=. prepare"
   },


### PR DESCRIPTION
Just realised we weren't exporting the styles from this package.

With this you can do `@import "@uqds/pagination";` with postcss-import.