### PR TITLE
fix: return swiper object from imageCarousel

### DIFF
--- a/packages/accordion/src/js/accordion.js
+++ b/packages/accordion/src/js/accordion.js
@@ -203,7 +203,9 @@ class accordion {
 
     // Wrap accordion content in a div tag that's used for layout without breaking the animation
     accordionContents.forEach((accordionContent) => {
-      if (!accordionContent.querySelector(`.${this.className}__content-wrapper`)) {
+      if (
+        !accordionContent.querySelector(`.${this.className}__content-wrapper`)
+      ) {
         const wrapper = document.createElement("div");
         wrapper.classList.add(`${this.className}__content-wrapper`);
         wrapper.replaceChildren(...accordionContent.childNodes);

--- a/packages/accordion/src/js/accordion.js
+++ b/packages/accordion/src/js/accordion.js
@@ -201,8 +201,14 @@ class accordion {
       });
     });
 
+    // Wrap accordion content in a div tag that's used for layout without breaking the animation
     accordionContents.forEach((accordionContent) => {
-      accordionContent.innerHTML = `<div class ="${this.className}__content-wrapper">${accordionContent.innerHTML}</div>`;
+      if (!accordionContent.querySelector(`.${this.className}__content-wrapper`)) {
+        const wrapper = document.createElement("div");
+        wrapper.classList.add(`${this.className}__content-wrapper`);
+        wrapper.replaceChildren(...accordionContent.childNodes);
+        accordionContent.appendChild(wrapper);
+      }
     });
   }
 }

--- a/packages/image/src/js/image-carousel.js
+++ b/packages/image/src/js/image-carousel.js
@@ -2,29 +2,33 @@ import Swiper from "swiper";
 import { Navigation, Pagination, A11y } from "swiper/modules";
 
 export const imageCarousel = (element) => {
-  if (element) {
-    const swiper = new Swiper(element, {
-      modules: [Navigation, Pagination, A11y],
-      pagination: {
-        el: ".uq-image-carousel__pagination",
-        bulletActiveClass: "is-active",
-        bulletClass: "uq-image-carousel__pagination-item",
-      },
-      navigation: {
-        nextEl: ".uq-image-carousel__next",
-        prevEl: ".uq-image-carousel__previous",
-      },
-    });
-
-    // Add count/index to each slide.
-    swiper.slides.forEach((slide, index) => {
-      const caption = slide.querySelector(".uq-image__caption");
-      if (caption) {
-        const counter = document.createElement("p");
-        counter.classList.add("uq-image-carousel__slide-counter");
-        counter.textContent = `${index + 1}/${swiper.slides.length}`;
-        caption.prepend(counter);
-      }
-    });
+  if (!element) {
+    return null;
   }
+
+  const swiper = new Swiper(element, {
+    modules: [Navigation, Pagination, A11y],
+    pagination: {
+      el: ".uq-image-carousel__pagination",
+      bulletActiveClass: "is-active",
+      bulletClass: "uq-image-carousel__pagination-item",
+    },
+    navigation: {
+      nextEl: ".uq-image-carousel__next",
+      prevEl: ".uq-image-carousel__previous",
+    },
+  });
+
+  // Add count/index to each slide.
+  swiper.slides.forEach((slide, index) => {
+    const caption = slide.querySelector(".uq-image__caption");
+    if (caption) {
+      const counter = document.createElement("p");
+      counter.classList.add("uq-image-carousel__slide-counter");
+      counter.textContent = `${index + 1}/${swiper.slides.length}`;
+      caption.prepend(counter);
+    }
+  });
+
+  return swiper;
 };


### PR DESCRIPTION
Will suit usages such as:

```js
Drupal.behaviors.uqdsImageCarousel = {
  attach: (context) => {
    const elements = once('uqdsImageCarousel', '.uq-image-carousel', context);
    elements.forEach(carousel => {
       const swiper = imageCarousel(carousel)
       swiper.on('slideChange', () => console.log('slide changed'))
    })
  }
}
```