### PR TITLE
fix(profile): reduced spacing of profile content gap

### DIFF
--- a/packages/profile/src/scss/_component.scss
+++ b/packages/profile/src/scss/_component.scss
@@ -10,7 +10,7 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  gap: core.$space-m;
+  gap: core.$space-s;
 
   :first-child {
     margin-top: core.$space-none;


### PR DESCRIPTION
Update the spacing between content sections within the Profiles component from 1rem to 0.5rem to strengthen proximity grouping. This will make it clearer that related content belongs to the associated profile, improving readability and scannability.