### PR TITLE
[Itsadssd 69461] profile analytics

### DIFF
--- a/packages/storybook-html/stories/components/profile/profile.mdx
+++ b/packages/storybook-html/stories/components/profile/profile.mdx
@@ -94,7 +94,8 @@ Examples of contextual usage of the profile component.
 dataLayer.push({
     'event' : 'Custom click',
     'click_category': 'Profile',
-    'click_action': 'link click',  
+    'click_action': 'link click',
     'click_label': '{{click text}}', // ’View Professor Jane Doe's profile'
     'click_url' : '{{href url}}', // 'https://about.uq.edu.au/experts/1371'
 });
+```

--- a/packages/storybook-html/stories/components/profile/profile.mdx
+++ b/packages/storybook-html/stories/components/profile/profile.mdx
@@ -66,3 +66,35 @@ Examples of contextual usage of the profile component.
 #### Expert profile
 
 <Canvas of={profileStories.ExpertProfile} />
+
+## Analytics
+
+**Profile container**
+
+<table>
+  <thead>
+    <tr>
+      <th>Property / DOM Target</th>
+      <th>Type</th>
+      <th>Value</th>
+      <th>Description & Logic</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`data-gtm-category` on `<article class="uq-profile">`</td>
+      <td>String</td>
+      <td>`"Profile"`</td>
+      <td>Defines the top-level tracking category for the entire profile component. All links and interactive elements within the profile component (email links, phone links, and profile view links) automatically inherit the "Profile" category from the parent container.</td>
+    </tr>
+  </tbody>
+</table>
+
+```
+dataLayer.push({
+    'event' : 'Custom click',
+    'click_category': 'Profile',
+    'click_action': 'link click',  
+    'click_label': '{{click text}}', // ’View Professor Jane Doe's profile'
+    'click_url' : '{{href url}}', // 'https://about.uq.edu.au/experts/1371'
+});

--- a/packages/storybook-html/stories/components/profile/profile.stories.js
+++ b/packages/storybook-html/stories/components/profile/profile.stories.js
@@ -98,7 +98,7 @@ export default {
     hasImage,
     image,
   }) => {
-    return `<article class="uq-profile">
+    return `<article class="uq-profile" data-gtm-category="Profile">
     <div class="uq-profile__content">
       <header class="uq-profile__header">
       <${titleElement} class="uq-profile__title">${honorificPrefix} ${name}</${titleElement}>


### PR DESCRIPTION
This PR adds analytics metadata documentation and markup for the Profile component in Storybook.

**Changes:**
- Adds `data-gtm-category="Profile"` to the Profile story container.
- Adds an Analytics section documenting the GTM category and example `dataLayer` event.