### PR TITLE
chore(previous-next): added exports to package

### DIFF
--- a/packages/previous-next/package.json
+++ b/packages/previous-next/package.json
@@ -30,6 +30,10 @@
     "src/*",
     "dist/*"
   ],
+  "exports": {
+    "./src/scss/*": "./src/scss/*"
+  },
+  "style": "dist/css/main.css",
   "scripts": {
     "prepare": "gulp -f ../../gulpfile.js --cwd=. prepare"
   },

--- a/packages/previous-next/src/scss/_component.scss
+++ b/packages/previous-next/src/scss/_component.scss
@@ -99,3 +99,5 @@
     font-weight: core.$font-weight-normal;
   }
 }
+
+/* comment to force version bump */

--- a/packages/previous-next/src/scss/_component.scss
+++ b/packages/previous-next/src/scss/_component.scss
@@ -1,4 +1,3 @@
-/* Pagination */
 @use "@uqds/core/src/scss/global" as core;
 @use "@uqds/icon/src/scss/global" as icon-constants;
 @use "global" as *;
@@ -99,5 +98,3 @@
     font-weight: core.$font-weight-normal;
   }
 }
-
-/* comment to force version bump */


### PR DESCRIPTION
# Description

Added missing `exports` and `style` fields to the `@uqds/previous-next` package.json to align with design system package conventions.

## Changes Detail

### `packages/previous-next/package.json`
- **Added `exports` field**: Defines SCSS source file exports pattern
  - `"./src/scss/*": "./src/scss/*"` - Allows importing SCSS files from the package
- **Added `style` field**: Points to the compiled CSS entry point
  - `"style": "dist/css/main.css"` - Standard CSS export for the package

## Impact

This change:
- ✅ Standardizes the package structure with other @uqds packages
- ✅ Enables proper SCSS imports from other packages/projects
- ✅ Provides correct CSS entry point for bundlers and build tools
- ✅ Follows the established export pattern used across the design system