### PR TITLE
chore: removing email address from website

### DIFF
--- a/docs/access-request.md
+++ b/docs/access-request.md
@@ -38,8 +38,7 @@ Access is managed through teams linked to the repo.
 
 ## Requests for access
 
-Requests for access are sent to its.softwareservices@uq.edu.au
-(Email currently goes to **team Aqua** (Tod or Adam))
+Submit Requests for access to [UQ Support](https://my.uq.edu.au/information-and-services/information-technology/student-staff-it-support)
 
 **Email Template**
 

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/acknowledgement/package.json
+++ b/packages/acknowledgement/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/app-maps/package.json
+++ b/packages/app-maps/package.json
@@ -16,8 +16,7 @@
   ],
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/blockquote/package.json
+++ b/packages/blockquote/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/body/package.json
+++ b/packages/body/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -14,8 +14,7 @@
   ],
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/grid-menu/package.json
+++ b/packages/grid-menu/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -14,8 +14,7 @@
   ],
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/hero/package.json
+++ b/packages/hero/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/lists/package.json
+++ b/packages/lists/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/loading-spinner/package.json
+++ b/packages/loading-spinner/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -18,8 +18,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -18,8 +18,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/pane/package.json
+++ b/packages/pane/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/pill/package.json
+++ b/packages/pill/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/previous-next/package.json
+++ b/packages/previous-next/package.json
@@ -18,8 +18,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/profile/package.json
+++ b/packages/profile/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/progression/package.json
+++ b/packages/progression/package.json
@@ -18,8 +18,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uqds/design-system#readme",
   "license": "ISC",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,8 +18,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/sections/package.json
+++ b/packages/sections/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/site-header/package.json
+++ b/packages/site-header/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/storybook-email/package.json
+++ b/packages/storybook-email/package.json
@@ -7,8 +7,7 @@
   "keywords": [],
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "license": "ISC",
   "scripts": {

--- a/packages/storybook-html/package.json
+++ b/packages/storybook-html/package.json
@@ -7,8 +7,7 @@
   "keywords": [],
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "license": "ISC",
   "scripts": {

--- a/packages/storybook-html/stories/components/core/browser-support.mdx
+++ b/packages/storybook-html/stories/components/core/browser-support.mdx
@@ -71,7 +71,7 @@ Refer to the following section for more detailed information on operating system
 
 ## Assessing individual site requirements
 
-If a solution requires significant backward compatibility, there should be discussion with the **ITS ADS UI** team and a review in the context of the application. You can request support from [webservices@uq.edu.au](mailto:webservices@uq.edu.au).
+If a solution requires significant backward compatibility, there should be discussion with the **ITS ADS UI** team and a review in the context of the application. You can request support from [ADS UI team](https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au).
 
 ### Modifying browser behaviour
 

--- a/packages/storybook-html/stories/introduction/get-started.mdx
+++ b/packages/storybook-html/stories/introduction/get-started.mdx
@@ -19,7 +19,7 @@ import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 
       If you have access, please refer to the <a href="https://confluence.its.uq.edu.au/confluence/x/0DwDCw"> environment setup instructions</a>.
 
-      If you do not have access, <a href="mailto:webservices@uq.edu.au"> contact us</a> and we can package up styles and components for you to use in your project.
+      If you do not have access, contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a>  and we can package up styles and components for you to use in your project.
     </p>
 
   </div>

--- a/packages/storybook-html/stories/introduction/get-started.mdx
+++ b/packages/storybook-html/stories/introduction/get-started.mdx
@@ -19,7 +19,7 @@ import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 
       If you have access, please refer to the <a href="https://confluence.its.uq.edu.au/confluence/x/0DwDCw"> environment setup instructions</a>.
 
-      If you do not have access, contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a>  and we can package up styles and components for you to use in your project.
+      If you do not have access, contact the <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au">ADS UI team</a>  and we can package up styles and components for you to use in your project.
     </p>
 
   </div>

--- a/packages/storybook-html/stories/introduction/overview.stories.js
+++ b/packages/storybook-html/stories/introduction/overview.stories.js
@@ -32,7 +32,7 @@ export const Overview = {
     title: "Overview",
     description: `
 <p>The Design System is a guide to how user interfaces should look, feel, and behave at UQ. The system provides styles, layouts, components, patterns, and examples of common user interfaces at UQ. It aims to help designers and developers build projects more easily and supports the application of the <a href="https://marketing-communication.uq.edu.au/one-brand">UQ Brand Guidelines</a> to ensure user interfaces across UQ are consistent.</p>
-<p>Follow our <a href="/design-system/packages/storybook-html/public?path=/docs/introduction-get-started--page">Get started</a> guide to see how you can use the Design System in your project. If your project has unique needs, you may need to adapt and extend what is provided in the system. If you want to share your work, contct <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a> to become a contributor.</p>`,
+<p>Follow our <a href="/design-system/packages/storybook-html/public?path=/docs/introduction-get-started--page">Get started</a> guide to see how you can use the Design System in your project. If your project has unique needs, you may need to adapt and extend what is provided in the system. If you want to share your work, contactt <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a> to become a contributor.</p>`,
   })}
   ${Section({
     title: "Community",

--- a/packages/storybook-html/stories/introduction/overview.stories.js
+++ b/packages/storybook-html/stories/introduction/overview.stories.js
@@ -32,12 +32,12 @@ export const Overview = {
     title: "Overview",
     description: `
 <p>The Design System is a guide to how user interfaces should look, feel, and behave at UQ. The system provides styles, layouts, components, patterns, and examples of common user interfaces at UQ. It aims to help designers and developers build projects more easily and supports the application of the <a href="https://marketing-communication.uq.edu.au/one-brand">UQ Brand Guidelines</a> to ensure user interfaces across UQ are consistent.</p>
-<p>Follow our <a href="/design-system/packages/storybook-html/public?path=/docs/introduction-get-started--page">Get started</a> guide to see how you can use the Design System in your project. If your project has unique needs, you may need to adapt and extend what is provided in the system. If you want to share your work, contactt <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a> to become a contributor.</p>`,
+<p>Follow our <a href="/design-system/packages/storybook-html/public?path=/docs/introduction-get-started--page">Get started</a> guide to see how you can use the Design System in your project. If your project has unique needs, you may need to adapt and extend what is provided in the system. If you want to share your work, contactt <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au">ADS UI team</a> to become a contributor.</p>`,
   })}
   ${Section({
     title: "Community",
     description: `
-<p>The Design System is managed and supported by the User Interface Design and Development team in ITS Application Development and Support (ADS-UI for short). Join the Design System community on <a class="text--link" href="https://www.yammer.com/uq.edu.au/#/threads/inGroup?type=in_group&feedId=35286523904">UQ Yammer</a> for updates and discussion or contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a>  with questions and feedback.</p>
+<p>The Design System is managed and supported by the User Interface Design and Development team in ITS Application Development and Support (ADS-UI for short). Join the Design System community on <a class="text--link" href="https://www.yammer.com/uq.edu.au/#/threads/inGroup?type=in_group&feedId=35286523904">UQ Yammer</a> for updates and discussion or contact the <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au">ADS UI team</a>  with questions and feedback.</p>
 <p>We'd love to come talk to your team about the design system and answer any questions you have.</p>`,
     content: `
 <div class="uq-card-grid uq-card-grid--target-3x">
@@ -68,7 +68,7 @@ export const Overview = {
     description: `
 <p>If UQ development teams work together, we can save time and build better.</p>
 <p>Our <a href="https://github.com/uq-its-ss/design-system">GitHub repository</a> contains all the code and content which make up the design system.</p>
-<p>Contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a>  if you'd like to contribute to the design system.</p>`,
+<p>contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au">ADS UI team</a>  if you'd like to contribute to the design system.</p>`,
   })}
   ${Section({
     title: "Why have a design system?",

--- a/packages/storybook-html/stories/introduction/overview.stories.js
+++ b/packages/storybook-html/stories/introduction/overview.stories.js
@@ -32,12 +32,12 @@ export const Overview = {
     title: "Overview",
     description: `
 <p>The Design System is a guide to how user interfaces should look, feel, and behave at UQ. The system provides styles, layouts, components, patterns, and examples of common user interfaces at UQ. It aims to help designers and developers build projects more easily and supports the application of the <a href="https://marketing-communication.uq.edu.au/one-brand">UQ Brand Guidelines</a> to ensure user interfaces across UQ are consistent.</p>
-<p>Follow our <a href="/design-system/packages/storybook-html/public?path=/docs/introduction-get-started--page">Get started</a> guide to see how you can use the Design System in your project. If your project has unique needs, you may need to adapt and extend what is provided in the system. If you want to share your work, <a href="mailto:webservices@uq.edu.au">contact us</a> to become a contributor.</p>`,
+<p>Follow our <a href="/design-system/packages/storybook-html/public?path=/docs/introduction-get-started--page">Get started</a> guide to see how you can use the Design System in your project. If your project has unique needs, you may need to adapt and extend what is provided in the system. If you want to share your work, contct <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a> to become a contributor.</p>`,
   })}
   ${Section({
     title: "Community",
     description: `
-<p>The Design System is managed and supported by the User Interface Design and Development team in ITS Application Development and Support (ADS-UI for short). Join the Design System community on <a class="text--link" href="https://www.yammer.com/uq.edu.au/#/threads/inGroup?type=in_group&feedId=35286523904">UQ Yammer</a> for updates and discussion or email the ADS UI team <a href="mailto:webservices@uq.edu.au">webservices@uq.edu.au</a> with questions and feedback.</p>
+<p>The Design System is managed and supported by the User Interface Design and Development team in ITS Application Development and Support (ADS-UI for short). Join the Design System community on <a class="text--link" href="https://www.yammer.com/uq.edu.au/#/threads/inGroup?type=in_group&feedId=35286523904">UQ Yammer</a> for updates and discussion or contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a>  with questions and feedback.</p>
 <p>We'd love to come talk to your team about the design system and answer any questions you have.</p>`,
     content: `
 <div class="uq-card-grid uq-card-grid--target-3x">
@@ -68,7 +68,7 @@ export const Overview = {
     description: `
 <p>If UQ development teams work together, we can save time and build better.</p>
 <p>Our <a href="https://github.com/uq-its-ss/design-system">GitHub repository</a> contains all the code and content which make up the design system.</p>
-<p>Contact <a href="mailto:webservices@uq.edu.au">ADS-UI</a> if you'd like to contribute to the design system.</p>`,
+<p>Contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a>  if you'd like to contribute to the design system.</p>`,
   })}
   ${Section({
     title: "Why have a design system?",

--- a/packages/storybook-react/package.json
+++ b/packages/storybook-react/package.json
@@ -6,8 +6,7 @@
   "keywords": [],
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "license": "ISC",
   "scripts": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -17,8 +17,7 @@
   },
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/uqds-builder/package.json
+++ b/packages/uqds-builder/package.json
@@ -5,8 +5,7 @@
   "private": true,
   "author": {
     "name": "University of Queensland",
-    "email": "webservices@uq.edu.au",
-    "url": "https://uq.edu.au"
+    "url": "https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"
   },
   "homepage": "https://github.com/uq-its-ss/design-system#readme",
   "license": "ISC",

--- a/packages/uqds-builder/src/index.html
+++ b/packages/uqds-builder/src/index.html
@@ -191,7 +191,7 @@
           <p>Follow our <a
               href="/design-system/packages/storybook-html/public?path=/docs/introduction-get-started--page">Get
               started</a> guide to see how you can use the Design System in your project. If your project has unique
-            needs, you may need to adapt and extend what is provided in the system. If you want to share your work, Contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a>  to become a contributor.</p>
+            needs, you may need to adapt and extend what is provided in the system. If you want to share your work, contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au">ADS UI team</a>  to become a contributor.</p>
         </div>
       </div>
 
@@ -259,7 +259,7 @@
             Application Development and Support (ADS-UI for short). Join the Design System community on <a
               class="text--link"
               href="https://www.yammer.com/uq.edu.au/#/threads/inGroup?type=in_group&amp;feedId=35286523904">UQ
-              Yammer</a> for updates and discussion or Contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a>  with questions and feedback.</p>
+              Yammer</a> for updates and discussion or contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au">ADS UI team</a>  with questions and feedback.</p>
           <p>We'd love to come talk to your team about the design system and answer any questions you have.</p>
         </div>
       </div>
@@ -319,7 +319,7 @@
           <p>If UQ development teams work together, we can save time and build better.</p>
           <p>Our <a href="https://github.com/uq-its-ss/design-system">GitHub repository</a> contains all the code and
             content which make up the design system.</p>
-          <p>Contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a>  if you'd like to contribute to the design system.
+          <p>contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au">ADS UI team</a>  if you'd like to contribute to the design system.
           </p>
         </div>
       </div>

--- a/packages/uqds-builder/src/index.html
+++ b/packages/uqds-builder/src/index.html
@@ -191,8 +191,7 @@
           <p>Follow our <a
               href="/design-system/packages/storybook-html/public?path=/docs/introduction-get-started--page">Get
               started</a> guide to see how you can use the Design System in your project. If your project has unique
-            needs, you may need to adapt and extend what is provided in the system. If you want to share your work, <a
-              href="mailto:webservices@uq.edu.au">contact us</a> to become a contributor.</p>
+            needs, you may need to adapt and extend what is provided in the system. If you want to share your work, Contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a>  to become a contributor.</p>
         </div>
       </div>
 
@@ -260,8 +259,7 @@
             Application Development and Support (ADS-UI for short). Join the Design System community on <a
               class="text--link"
               href="https://www.yammer.com/uq.edu.au/#/threads/inGroup?type=in_group&amp;feedId=35286523904">UQ
-              Yammer</a> for updates and discussion or email the ADS UI team <a
-              href="mailto:webservices@uq.edu.au">webservices@uq.edu.au</a> with questions and feedback.</p>
+              Yammer</a> for updates and discussion or Contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a>  with questions and feedback.</p>
           <p>We'd love to come talk to your team about the design system and answer any questions you have.</p>
         </div>
       </div>
@@ -321,7 +319,7 @@
           <p>If UQ development teams work together, we can save time and build better.</p>
           <p>Our <a href="https://github.com/uq-its-ss/design-system">GitHub repository</a> contains all the code and
             content which make up the design system.</p>
-          <p>Contact <a href="mailto:webservices@uq.edu.au">ADS-UI</a> if you'd like to contribute to the design system.
+          <p>Contact <a href="https://about.uq.edu.au/web-feedback?r=https://design-system.uq.edu.au"> ADS UI team</a>  if you'd like to contribute to the design system.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Removes direct references to the `webservices@uq.edu.au` email address across the UQ Design System website/Storybook content and package metadata, replacing them with a central web feedback contact URL.

**Changes:**
- Replaces `mailto:webservices@uq.edu.au` links in HTML/MDX/Storybook content with the ADS UI web feedback link.
- Updates multiple `package.json` `author` blocks to remove the `email` field and point `author.url` to the web feedback link.
- Updates copy in the builder site’s `index.html` to use the new contact destination.